### PR TITLE
Removing environment setup on DAG

### DIFF
--- a/src/ingest-pipeline/airflow/dags/aws_utils.py
+++ b/src/ingest-pipeline/airflow/dags/aws_utils.py
@@ -23,10 +23,10 @@ def create_key_pair(key_name: str):
     client = AwsBaseHook(client_type="ec2").get_conn()
 
     try:
-        key_pair_id = client.import_key_pair(KeyName=key_name)["KeyName"]
-    except:
-        print(f'No {key_name} key_pair found, expected behavior')
         key_pair_id = client.create_key_pair(KeyName=key_name)["KeyName"]
+    except:
+        key_pair_id = key_name
+        print(f'Was the {key_name} key before the call?')
     # Creating the key takes a very short but measurable time, preventing race condition:
     client.get_waiter("key_pair_exists").wait(KeyNames=[key_pair_id])
 

--- a/src/ingest-pipeline/airflow/dags/launch_multi_analysis.py
+++ b/src/ingest-pipeline/airflow/dags/launch_multi_analysis.py
@@ -13,14 +13,7 @@ from utils import (
     localized_assert_json_matches_schema as assert_json_matches_schema,
     HMDAG,
     get_queue_resource,
-    get_preserve_scratch_resource,
-    get_instance_type,
-    get_environment_instance
-)
-
-from aws_utils import (
-    create_instance,
-    terminate_instance
+    get_preserve_scratch_resource
 )
 
 
@@ -54,25 +47,6 @@ with HMDAG('launch_multi_analysis',
                'tmp_dir_path': utils.get_tmp_dir_path,
                'preserve_scratch': get_preserve_scratch_resource('launch_multi_analysis')
            }) as dag:
-
-    def start_new_environment(**kwargs):
-        uuid = kwargs['dag_run'].conf['submission_id']
-        instance_id = create_instance(uuid, f'Airflow {get_environment_instance()} Worker',
-                                      get_instance_type(kwargs.get('dag_id')))
-        if instance_id is None:
-            return 1
-        else:
-            kwargs['ti'].xcom_push(key='instance_id', value=instance_id)
-            return 0
-
-
-    t_initialize_environment = PythonOperator(
-        task_id='initialize_environment',
-        python_callable=start_new_environment,
-        provide_context=True,
-        op_kwargs={
-        }
-    )
 
     def check_one_uuid(uuid, **kwargs):
         """
@@ -208,21 +182,4 @@ with HMDAG('launch_multi_analysis',
             }
         )
 
-    def terminate_new_environment(**kwargs):
-        instance_id = kwargs['ti'].xcom_pull(key='instance_id', task_ids="initialize_environment")
-        if instance_id is None:
-            return 1
-        else:
-            uuid = kwargs['dag_run'].conf['submission_id']
-            terminate_instance(instance_id, uuid)
-        return 0
-
-    t_terminate_environment = PythonOperator(
-        task_id='terminate_environment',
-        python_callable=terminate_new_environment,
-        provide_context=True,
-        op_kwargs={
-        }
-    )
-
-    t_initialize_environment >> check_uuids_t >> t_maybe_spawn >> t_terminate_environment
+    check_uuids_t >> t_maybe_spawn

--- a/src/ingest-pipeline/airflow/dags/resource_map.yml
+++ b/src/ingest-pipeline/airflow/dags/resource_map.yml
@@ -13,7 +13,7 @@ resource_map:
   - 'dag_re': 'celldive_deepcell'
     'preserve_scratch': true
     'lanes': 2
-    'instance_type': 'r5.xlarge'
+    'instance_type': 'r6i.xlarge'
     'tasks':
     - 'task_re': '.*segmentation'
       'queue': 'gpu000_q1'
@@ -28,7 +28,7 @@ resource_map:
     'preserve_scratch': true
     'lanes': 2
     # 'lanes': 12
-    'instance_type': 'r5.xlarge'
+    'instance_type': 'r6i.xlarge'
     'tasks':
     - 'task_re': '.*cwl.*|.*exec|.*cmd.*|.*azimuth.*|.*ui.*'
       'queue': 'processing'
@@ -56,7 +56,7 @@ resource_map:
     'preserve_scratch': true
     'lanes': 2
     # 'lanes': 6
-    'instance_type': 'r5.4xlarge'
+    'instance_type': 'r6i.8xlarge'
     'tasks':
     - 'task_re': '^(?!maybe_keep)(.*cwl_cytokit)'
       'queue': 'gpu000_q1'
@@ -75,7 +75,7 @@ resource_map:
     'preserve_scratch': true
     'lanes': 2
     # 'lanes': 6
-    'instance_type': 'r5.xlarge'
+    'instance_type': 'r6i.xlarge'
     'tasks':
     - 'task_re': '.*'
       'queue': 'general'
@@ -125,7 +125,7 @@ resource_map:
     'preserve_scratch': true
     'lanes': 8
     # 'lanes': 11
-    'instance_type': 'r5.xlarge'
+    'instance_type': 'r6i.xlarge'
     'tasks':
     - 'task_re': '.*'
       'queue': 'general'
@@ -133,7 +133,7 @@ resource_map:
   - 'dag_re': '.*'
     'preserve_scratch': true
     'lanes': 2
-    'instance_type': 'c6a.medium'
+    'instance_type': 't3a.medium'
     'tasks':
       - 'task_re': '.*'
         'queue': 'general'


### PR DESCRIPTION
Launch multi analysis DAG doesn't require an environment to run.
Optimized CPU instances based on tests.
Updated exception control on keypair creation.