### PR TITLE
Bugfix missing information on azimuth_annotations

### DIFF
--- a/src/ingest-pipeline/airflow/dags/bulk_process.py
+++ b/src/ingest-pipeline/airflow/dags/bulk_process.py
@@ -55,8 +55,7 @@ with HMDAG(
 ) as dag:
 
     def check_one_uuid(
-        uuid: str, previous_version_uuid: str, avoid_previous_version: bool,
-        collection_type: str, **kwargs
+        uuid: str, previous_version_uuid: str, avoid_previous_version: bool, **kwargs
     ):
         """
         Look up information on the given uuid or HuBMAP identifier.
@@ -92,8 +91,7 @@ with HMDAG(
                 previous_version_uuid = previous_uuid
 
         return (
-            ds_rslt["uuid"] if collection_type != "reversioning_annotations" else
-            ds_rslt["parent_dataset_uuid_list"],
+            ds_rslt["uuid"],
             dt,
             ds_rslt["local_directory_full_path"],
             ds_rslt["metadata"],
@@ -118,7 +116,7 @@ with HMDAG(
         filtered_uuid_l = []
         for uuid in uuid_l:
             uuid, dt, lz_path, metadata, prev_version_uuid = check_one_uuid(
-                uuid, prev_version_uuid, avoid_previous_version, collection_type, **kwargs
+                uuid, prev_version_uuid, avoid_previous_version, **kwargs
             )
             soft_data_assaytype = get_soft_data_assaytype(
                 uuid[0] if isinstance(uuid, list) else uuid, **kwargs)

--- a/src/ingest-pipeline/airflow/dags/launch_multi_analysis.py
+++ b/src/ingest-pipeline/airflow/dags/launch_multi_analysis.py
@@ -55,8 +55,7 @@ with HMDAG(
 ) as dag:
 
     def check_one_uuid(
-        uuid: str, previous_version_uuid: str, avoid_previous_version: bool,
-        collection_type: str, **kwargs
+        uuid: str, previous_version_uuid: str, avoid_previous_version: bool, **kwargs
     ):
         """
         Look up information on the given uuid or HuBMAP identifier.
@@ -92,8 +91,7 @@ with HMDAG(
                 previous_version_uuid = previous_uuid
 
         return (
-            ds_rslt["uuid"] if collection_type != "reversioning_annotations" else
-            ds_rslt["parent_dataset_uuid_list"],
+            ds_rslt["uuid"],
             dt,
             ds_rslt["local_directory_full_path"],
             ds_rslt["metadata"],
@@ -121,7 +119,7 @@ with HMDAG(
         filtered_md_l = []
         for uuid in uuid_l:
             uuid, dt, lz_path, metadata, prev_version_uuid = check_one_uuid(
-                uuid, prev_version_uuid, avoid_previous_version, collection_type, **kwargs
+                uuid, prev_version_uuid, avoid_previous_version, **kwargs
             )
             soft_data_assaytype = get_soft_data_assaytype(
                 uuid[0] if isinstance(uuid, list) else uuid, **kwargs)

--- a/src/ingest-pipeline/airflow/dags/utils.py
+++ b/src/ingest-pipeline/airflow/dags/utils.py
@@ -296,6 +296,9 @@ def build_dataset_name(dag_id: str, pipeline_str: str, **kwargs) -> str:
 
 def get_parent_dataset_uuids_list(**kwargs) -> List[str]:
     uuid_list = kwargs["dag_run"].conf["parent_submission_id"]
+    if kwargs["dag"].dag_id == "azimuth_annotations":
+        uuid_list = pythonop_get_dataset_state(dataset_uuid_callable=lambda **kwargs: uuid_list[0],
+                                               **kwargs).get("parent_dataset_uuid_list")
     if not isinstance(uuid_list, list):
         uuid_list = [uuid_list]
     return uuid_list


### PR DESCRIPTION
Bugfix missing information on azimuth_annotations due to dealing with parent dataset metadata instead of processed metadata, updating the get parent function to return primary parent datasets for azimuth_annotations dag so the provenance is consistent.